### PR TITLE
Replace https module with http2 server

### DIFF
--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -6,7 +6,7 @@ var createSniCallback = require('./sni-callback').create;
 var LE = require('letsencrypt');
 
 function LEX(obj, app) {
-  var https = require('https');
+  var https = require('spdy');
   var http = require('http');
   var defaultPems = require('localhost.daplie.com-certificates');
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "homedir": "^0.6.0",
     "letsencrypt": "^1.4.0",
     "localhost.daplie.com-certificates": "^1.1.2",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "spdy": "^3.0.0"
   }
 }


### PR DESCRIPTION
Would love to have http2 support. This PR replaces the https module with a quite well tested http2 server that automatically falls back to https if the client does not support http2.

Going to use this in our system.