### PR TITLE
printing primitive arrays in opts in one line

### DIFF
--- a/lib/sni-callback.js
+++ b/lib/sni-callback.js
@@ -19,8 +19,13 @@ module.exports.create = function (opts) {
 
   if (!opts) { throw new Error("requires opts to be an object"); }
   if (opts.debug) {
-    console.debug("[LEX] creating sniCallback", JSON.stringify(opts, null, '  '));
+    console.debug("[LEX] creating sniCallback", JSON.stringify(opts, function(k,v){
+      if(v instanceof Array)
+         return JSON.stringify(v);
+      return v;
+    },'  '));
   }
+  
   if (!opts.letsencrypt) { throw new Error("requires opts.letsencrypt to be a letsencrypt instance"); }
 
   if (!opts.lifetime) { opts.lifetime = 90 * 24 * 60 * 60 * 1000; }


### PR DESCRIPTION
This fixes #22 and prints all arrays that contain only primitive values in one line like the key or cert buffer