### PR TITLE
Allow for custom ca set on httpsOptions to be used in the createSecure…

### DIFF
--- a/lib/sni-callback.js
+++ b/lib/sni-callback.js
@@ -102,6 +102,7 @@ module.exports.create = function (opts) {
         certInfo.tlsContext = tls.createSecureContext({
           key: certInfo.privkey || certInfo.key         // privkey.pem
         , cert: certInfo.fullchain || certInfo.cert     // fullchain.pem (cert.pem + '\n' + chain.pem)
+        , ca: (opts.httpsOptions.ca ? opts.httpsOptions.ca + '\n' + certInfo.ca : certInfo.ca)
         });
       } catch(e) {
         console.warn("[Sanity Check Fail]: a weird object was passed back through le.fetch to lex.fetch");


### PR DESCRIPTION
Allow for custom ca set on httpsOptions to be used in the createSecure call. This will resolve issue #35 by allowing a custom ca to be used in combination with raw http / https modules.