### PR TITLE
redirect all http request actions to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ var https = require('spdy');
 function redirectHttp() {
   http.createServer(LEX.createAcmeResponder(lex, function redirectHttps(req, res) {
     res.setHeader('Location', 'https://' + req.headers.host + req.url);
-    res.statusCode = 302;
+    res.statusCode = 302; // use 307 if you want to redirect requests with POST, DELETE or PUT action.
     res.end('<!-- Hello Developer Person! Please use HTTPS instead -->');
   })).listen(80);
 }


### PR DESCRIPTION

> 
Note: RFC 1945 and RFC 2068 specify that the client is not allowed to change the method on the redirected request. However, most existing user agent implementations treat 302 as if it were a 303 response, performing a GET on the Location field-value regardless of the original request method. The status codes 303 and 307 have been added for servers that wish to make unambiguously clear which kind of reaction is expected of the client.


http://stackoverflow.com/questions/2068418/whats-the-difference-between-a-302-and-a-307-redirect